### PR TITLE
Ndlano/issues#458 listing master category

### DIFF
--- a/src/main/scala/no/ndla/listingapi/controller/ListingController.scala
+++ b/src/main/scala/no/ndla/listingapi/controller/ListingController.scala
@@ -14,6 +14,7 @@ import no.ndla.listingapi.ListingApiProperties.{DefaultLanguage, DefaultPageSize
 import no.ndla.listingapi.auth.Role
 import no.ndla.listingapi.model.api.{Error, NewCover, UpdateCover, ValidationError}
 import no.ndla.listingapi.model.domain.search.Sort
+import no.ndla.listingapi.model.meta.Theme
 import no.ndla.listingapi.repository.ListingRepository
 import no.ndla.listingapi.service._
 import no.ndla.listingapi.service.search.SearchService
@@ -99,6 +100,16 @@ trait ListingController {
       searchService.matchingQuery(filter, language, page.toInt, pageSize.toInt, sort)
     }
 
+
+    get("/theme/:theme") {
+      val theme = params("theme")
+      val language = paramOrDefault("language", DefaultLanguage)
+      theme match {
+        case theme if Theme.allowedThemes.contains(theme) => readService.getTheme(theme, language)
+        case _ => NotFound(body = Error(Error.NOT_FOUND, s"No theme with name '$theme' is configured."))
+      }
+    }
+
     put("/:coverid", operation(updateCoverDoc)) {
       authRole.assertHasRole(RoleWithWriteAccess)
       writeService.updateCover(long("coverid"), extract[UpdateCover](request.body))
@@ -110,7 +121,7 @@ trait ListingController {
 
       readService.coverWithId(coverId, language) match {
         case Some(cover) => cover
-        case None => NotFound(body = Error(Error.NOT_FOUND, s"No cover with id $coverId found"))
+        case None => NotFound(body = Error(Error.NOT_FOUND, s"No cover with id $coverId found."))
       }
     }
 

--- a/src/main/scala/no/ndla/listingapi/controller/ListingController.scala
+++ b/src/main/scala/no/ndla/listingapi/controller/ListingController.scala
@@ -82,6 +82,15 @@ trait ListingController {
         )
         authorizations "oauth2"
         responseMessages(response400, response403, response404, response500))
+    val getThemeDoc =
+      (apiOperation[String]("getTheme")
+        summary "Returns a sequence of covers with a named theme. Themes are predefined and should be known to the caller. "
+        notes s"Returns  a sequence of covers with a named theme given the current language. Default is $DefaultLanguage."
+        parameter (
+        queryParam[Option[String]]("language").description(s"Return the covers of the theme in this language. Default is $DefaultLanguage")
+        )
+        authorizations "oauth2"
+        responseMessages(response400, response403, response404, response500))
 
     protected val applicationDescription = "API for grouping content from ndla.no."
 
@@ -101,7 +110,7 @@ trait ListingController {
     }
 
 
-    get("/theme/:theme") {
+    get("/theme/:theme", operation(getThemeDoc)) {
       val theme = params("theme")
       val language = paramOrDefault("language", DefaultLanguage)
       theme match {

--- a/src/main/scala/no/ndla/listingapi/controller/ListingController.scala
+++ b/src/main/scala/no/ndla/listingapi/controller/ListingController.scala
@@ -12,7 +12,7 @@ package no.ndla.listingapi.controller
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.listingapi.ListingApiProperties.{DefaultLanguage, DefaultPageSize, RoleWithWriteAccess}
 import no.ndla.listingapi.auth.Role
-import no.ndla.listingapi.model.api.{Error, NewCover, UpdateCover, ValidationError}
+import no.ndla.listingapi.model.api.{Error, NewCover, ThemeResult, UpdateCover, ValidationError}
 import no.ndla.listingapi.model.domain.search.Sort
 import no.ndla.listingapi.model.meta.Theme
 import no.ndla.listingapi.repository.ListingRepository
@@ -83,7 +83,7 @@ trait ListingController {
         authorizations "oauth2"
         responseMessages(response400, response403, response404, response500))
     val getThemeDoc =
-      (apiOperation[String]("getTheme")
+      (apiOperation[ThemeResult]("getTheme")
         summary "Returns a sequence of covers with a named theme. Themes are predefined and should be known to the caller. "
         notes s"Returns  a sequence of covers with a named theme given the current language. Default is $DefaultLanguage."
         parameter (
@@ -115,7 +115,7 @@ trait ListingController {
       val language = paramOrDefault("language", DefaultLanguage)
       theme match {
         case theme if Theme.allowedThemes.contains(theme) => readService.getTheme(theme, language)
-        case _ => NotFound(body = Error(Error.NOT_FOUND, s"No theme with name '$theme' is configured."))
+        case _ => BadRequest(body = Error(Error.VALIDATION, s"No theme with name '$theme' is configured."))
       }
     }
 

--- a/src/main/scala/no/ndla/listingapi/model/api/Cover.scala
+++ b/src/main/scala/no/ndla/listingapi/model/api/Cover.scala
@@ -26,5 +26,6 @@ case class Cover(
   @(ApiModelProperty@field)(description = "The labels associated with this cover") labels: Seq[Label],
   @(ApiModelProperty@field)(description = "The languages this cover supports") supportedLanguages: Seq[String],
   @(ApiModelProperty@field)(description = "The user id that last updated the cover") updatedBy: String,
-  @(ApiModelProperty@field)(description = "When the cover was last updated") updated: Date
+  @(ApiModelProperty@field)(description = "When the cover was last updated") updated: Date,
+  @(ApiModelProperty@field)(description = "The meta theme associated with this cover") theme: String
 )

--- a/src/main/scala/no/ndla/listingapi/model/api/NewCover.scala
+++ b/src/main/scala/no/ndla/listingapi/model/api/NewCover.scala
@@ -1,5 +1,7 @@
 package no.ndla.listingapi.model.api
 
+import no.ndla.listingapi.model.domain.ThemeName
+import no.ndla.listingapi.model.meta.Theme
 import org.scalatra.swagger.annotations.ApiModel
 import org.scalatra.swagger.runtime.annotations.ApiModelProperty
 
@@ -7,10 +9,11 @@ import scala.annotation.meta.field
 
 @ApiModel(description = "Meta information for a new cover")
 case class NewCover(@(ApiModelProperty@field)(description = "The language in this request") language: String,
-                    @(ApiModelProperty@field)(description = "A cover photo for the cover") coverPhotoUrl: String,
-                    @(ApiModelProperty@field)(description = "The title for this cover") title: String,
-                    @(ApiModelProperty@field)(description = "The description for this cover") description: String,
-                    @(ApiModelProperty@field)(description = "The link to the article") articleApiId: Long,
-                    @(ApiModelProperty@field)(description = "The id of the old article") oldNodeId: Option[Long],
-                    @(ApiModelProperty@field)(description = "The labels associated with this cover") labels: Seq[Label]
-                   )
+  @(ApiModelProperty@field)(description = "A cover photo for the cover") coverPhotoUrl: String,
+  @(ApiModelProperty@field)(description = "The title for this cover") title: String,
+  @(ApiModelProperty@field)(description = "The description for this cover") description: String,
+  @(ApiModelProperty@field)(description = "The link to the article") articleApiId: Long,
+  @(ApiModelProperty@field)(description = "The id of the old article") oldNodeId: Option[Long],
+  @(ApiModelProperty@field)(description = "The labels associated with this cover") labels: Seq[Label],
+  @(ApiModelProperty@field)(description = "The meta theme associated with this cover") theme: String
+)

--- a/src/main/scala/no/ndla/listingapi/model/api/ThemeResult.scala
+++ b/src/main/scala/no/ndla/listingapi/model/api/ThemeResult.scala
@@ -1,0 +1,11 @@
+package no.ndla.listingapi.model.api
+
+import org.scalatra.swagger.annotations.ApiModel
+import org.scalatra.swagger.runtime.annotations.ApiModelProperty
+
+import scala.annotation.meta.field
+
+@ApiModel(description = "Information about theme-results") case class ThemeResult(
+  @(ApiModelProperty@field)(description = "The total number of covers matching this theme") totalCount: Long,
+  @(ApiModelProperty@field)(description = "The search results") results: Seq[Cover]
+)

--- a/src/main/scala/no/ndla/listingapi/model/api/UpdateCover.scala
+++ b/src/main/scala/no/ndla/listingapi/model/api/UpdateCover.scala
@@ -7,10 +7,11 @@ import scala.annotation.meta.field
 
 @ApiModel(description = "Meta information for a updated cover")
 case class UpdateCover(@(ApiModelProperty@field)(description = "The language in this request") language: String,
-                       @(ApiModelProperty@field)(description = "The revision number of this cover") revision: Int,
-                       @(ApiModelProperty@field)(description = "A cover photo for the cover") coverPhotoUrl: Option[String],
-                       @(ApiModelProperty@field)(description = "The link to the article") articleApiId: Option[Long],
-                       @(ApiModelProperty@field)(description = "The title for this cover") title: String,
-                       @(ApiModelProperty@field)(description = "The description for this cover") description: String,
-                       @(ApiModelProperty@field)(description = "The labels associated with this cover") labels: Seq[Label]
-                   )
+  @(ApiModelProperty@field)(description = "The revision number of this cover") revision: Int,
+  @(ApiModelProperty@field)(description = "A cover photo for the cover") coverPhotoUrl: Option[String],
+  @(ApiModelProperty@field)(description = "The link to the article") articleApiId: Option[Long],
+  @(ApiModelProperty@field)(description = "The title for this cover") title: String,
+  @(ApiModelProperty@field)(description = "The description for this cover") description: String,
+  @(ApiModelProperty@field)(description = "The labels associated with this cover") labels: Seq[Label],
+  @(ApiModelProperty@field)(description = "The meta theme associated with this cover") theme: String
+)

--- a/src/main/scala/no/ndla/listingapi/model/domain/Cover.scala
+++ b/src/main/scala/no/ndla/listingapi/model/domain/Cover.scala
@@ -11,7 +11,6 @@ import java.util.Date
 
 import no.ndla.listingapi.ListingApiProperties
 import no.ndla.listingapi.model.api.NotFoundException
-import no.ndla.listingapi.model.meta.Theme
 import org.json4s.FieldSerializer
 import org.json4s.FieldSerializer.ignore
 import org.json4s.native.Serialization._
@@ -20,17 +19,17 @@ import scalikejdbc._
 import scala.util.{Failure, Success, Try}
 
 case class Cover(id: Option[Long],
-                 revision: Option[Int],
-                 oldNodeId: Option[Long],
-                 coverPhotoUrl: String,
-                 title: Seq[Title],
-                 description: Seq[Description],
-                 labels: Seq[LanguageLabels],
-                 articleApiId: Long,
-                 updatedBy: String,
-                 updated: Date,
-                 theme: ThemeName
-                ) {
+  revision: Option[Int],
+  oldNodeId: Option[Long],
+  coverPhotoUrl: String,
+  title: Seq[Title],
+  description: Seq[Description],
+  labels: Seq[LanguageLabels],
+  articleApiId: Long,
+  updatedBy: String,
+  updated: Date,
+  theme: ThemeName
+) {
   def getAllCoverLanguages: Try[Seq[String]] = {
     val titleLangs = title.flatMap(_.language)
     val descriptionLangs = description.flatMap(_.language)
@@ -47,7 +46,10 @@ object Cover extends SQLSyntaxSupport[Cover] {
   implicit val formats = org.json4s.DefaultFormats
   override val tableName = "covers"
   override val schemaName = Some(ListingApiProperties.MetaSchema)
-
+  val JSonSerializer = FieldSerializer[Cover](
+    ignore("id") orElse
+      ignore("revision")
+  )
 
   def apply(s: SyntaxProvider[Cover])(rs: WrappedResultSet): Cover = apply(s.resultName)(rs)
 
@@ -66,9 +68,4 @@ object Cover extends SQLSyntaxSupport[Cover] {
       meta.theme
     )
   }
-
-  val JSonSerializer = FieldSerializer[Cover](
-    ignore("id") orElse
-      ignore("revision")
-  )
 }

--- a/src/main/scala/no/ndla/listingapi/model/domain/Cover.scala
+++ b/src/main/scala/no/ndla/listingapi/model/domain/Cover.scala
@@ -11,6 +11,7 @@ import java.util.Date
 
 import no.ndla.listingapi.ListingApiProperties
 import no.ndla.listingapi.model.api.NotFoundException
+import no.ndla.listingapi.model.meta.Theme
 import org.json4s.FieldSerializer
 import org.json4s.FieldSerializer.ignore
 import org.json4s.native.Serialization._
@@ -27,7 +28,8 @@ case class Cover(id: Option[Long],
                  labels: Seq[LanguageLabels],
                  articleApiId: Long,
                  updatedBy: String,
-                 updated: Date
+                 updated: Date,
+                 theme: ThemeName
                 ) {
   def getAllCoverLanguages: Try[Seq[String]] = {
     val titleLangs = title.flatMap(_.language)
@@ -60,7 +62,8 @@ object Cover extends SQLSyntaxSupport[Cover] {
       meta.labels,
       meta.articleApiId,
       meta.updatedBy,
-      meta.updated
+      meta.updated,
+      meta.theme
     )
   }
 

--- a/src/main/scala/no/ndla/listingapi/model/domain/package.scala
+++ b/src/main/scala/no/ndla/listingapi/model/domain/package.scala
@@ -11,6 +11,7 @@ package object domain {
   type Lang = String
   type LabelType = String
   type LabelName = String
+  type ThemeName = String
 
   def emptySomeToNone(lang: Option[String]): Option[String] = lang.filter(_.nonEmpty)
 

--- a/src/main/scala/no/ndla/listingapi/model/domain/search/SearchableCover.scala
+++ b/src/main/scala/no/ndla/listingapi/model/domain/search/SearchableCover.scala
@@ -31,5 +31,6 @@ case class SearchableCover(
   labels: SearchableLanguageList,
   supportedLanguages: Seq[String],
   updatedBy: String,
-  update: Date
+  update: Date,
+  theme: String
 )

--- a/src/main/scala/no/ndla/listingapi/model/meta/Theme.scala
+++ b/src/main/scala/no/ndla/listingapi/model/meta/Theme.scala
@@ -1,0 +1,8 @@
+package no.ndla.listingapi.model.meta
+
+//The meta theme of a group av covers. Correspond to the wanted separation of listings which is not
+// to be used in the filtering functionality. Filtering of covers happens within a theme in the client.
+
+object Theme {
+  val allowedThemes :List [String] = List("naturbruk", "verktoy")
+}

--- a/src/main/scala/no/ndla/listingapi/model/meta/Theme.scala
+++ b/src/main/scala/no/ndla/listingapi/model/meta/Theme.scala
@@ -4,8 +4,8 @@ package no.ndla.listingapi.model.meta
 // to be used in the filtering functionality. Filtering of covers happens within a theme in the client.
 
 object Theme {
-  lazy val VERKTOY = "verktoy"
-  lazy val NATURBRUK = "naturbruk"
+  val VERKTOY = "verktoy"
+  val NATURBRUK = "naturbruk"
 
   val allowedThemes :List [String] = List(NATURBRUK, VERKTOY)
 }

--- a/src/main/scala/no/ndla/listingapi/model/meta/Theme.scala
+++ b/src/main/scala/no/ndla/listingapi/model/meta/Theme.scala
@@ -1,8 +1,11 @@
 package no.ndla.listingapi.model.meta
 
-//The meta theme of a group av covers. Correspond to the wanted separation of listings which is not
+//The meta theme of a group av covers. Corresponds to the wanted separation of listings which is not
 // to be used in the filtering functionality. Filtering of covers happens within a theme in the client.
 
 object Theme {
-  val allowedThemes :List [String] = List("naturbruk", "verktoy")
+  lazy val VERKTOY = "verktoy"
+  lazy val NATURBRUK = "naturbruk"
+
+  val allowedThemes :List [String] = List(NATURBRUK, VERKTOY)
 }

--- a/src/main/scala/no/ndla/listingapi/repository/ListingRepository.scala
+++ b/src/main/scala/no/ndla/listingapi/repository/ListingRepository.scala
@@ -78,6 +78,10 @@ trait ListingRepository {
       sql"delete from ${Cover.table} where id = $coverId".update.apply
     }
 
+    def getTheme(theme: ThemeName): Seq[Cover] = {
+      coversWhere(sqls"c.document->>'theme' = $theme")
+    }
+
     /* Group the labels by language in a Map, for each language there is a Map of labels by type.
       This is to go in the cache.
     */

--- a/src/main/scala/no/ndla/listingapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/ConverterService.scala
@@ -32,7 +32,8 @@ trait ConverterService {
               getByLanguage[Seq[domain.Label], LanguageLabels](cover.labels, language).getOrElse(Seq.empty).map(toApiLabel),
               langs,
               cover.updatedBy,
-              cover.updated
+              cover.updated,
+              cover.theme
             ))
         }
       }
@@ -51,7 +52,8 @@ trait ConverterService {
         Seq(LanguageLabels(cover.labels.map(toDomainLabel), Option(cover.language))),
         cover.articleApiId,
         authUser.id(),
-        clock.now()
+        clock.now(),
+        cover.theme
       )
     }
 

--- a/src/main/scala/no/ndla/listingapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/ConverterService.scala
@@ -60,4 +60,5 @@ trait ConverterService {
     def toDomainLabel(label: api.Label): domain.Label = domain.Label(label.`type`, label.labels)
 
   }
+
 }

--- a/src/main/scala/no/ndla/listingapi/service/CoverValidator.scala
+++ b/src/main/scala/no/ndla/listingapi/service/CoverValidator.scala
@@ -12,6 +12,7 @@ import com.netaporter.uri.Uri._
 import no.ndla.listingapi.model.api.{ValidationException, ValidationMessage}
 import no.ndla.listingapi.model.domain
 import no.ndla.listingapi.model.domain.Cover
+import no.ndla.listingapi.model.meta.Theme
 import no.ndla.mapping.ISO639.get6391CodeFor6392CodeMappings
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
@@ -39,7 +40,8 @@ trait CoverValidator {
         cover.labels.flatMap(validateLanguageLabels) ++
         validateCoverPhoto(cover.coverPhotoUrl) ++
         cover.id.flatMap(id => validateId("id", id)) ++
-        validateId("articleApiId", cover.articleApiId)
+        validateId("articleApiId", cover.articleApiId) ++
+        validateTheme(cover.theme)
     }
 
     private def validateDescription(description: domain.Description): Seq[ValidationMessage] = {
@@ -96,6 +98,13 @@ trait CoverValidator {
       languageCodeSupported6391(languageCode) match {
         case true => None
         case false => Some(ValidationMessage(fieldPath, s"Language '$languageCode' is not a supported value."))
+      }
+    }
+
+    private def validateTheme(name: domain.ThemeName): Option[ValidationMessage] = {
+      Theme.allowedThemes.contains(name.toLowerCase) match {
+        case true => None
+        case false => Some(ValidationMessage(name, s"Theme name '$name' is not a supportet theme."))
       }
     }
 

--- a/src/main/scala/no/ndla/listingapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/ReadService.scala
@@ -3,6 +3,7 @@ package no.ndla.listingapi.service
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.listingapi.caching.MemoizeAutoRenew
 import no.ndla.listingapi.model.api
+import no.ndla.listingapi.model.api.ThemeResult
 import no.ndla.listingapi.model.domain.{Lang, ThemeName, UniqeLabels}
 import no.ndla.listingapi.repository.ListingRepository
 
@@ -23,8 +24,9 @@ trait ReadService {
       getAllLabelsMap()
     }
 
-    def getTheme(theme: ThemeName, language: String): Seq[api.Cover] = {
-      listingRepository.getTheme(theme).flatMap(t => converterService.toApiCover(t, language).toOption)
+    def getTheme(theme: ThemeName, language: String): api.ThemeResult = {
+      val covers = listingRepository.getTheme(theme).flatMap(t => converterService.toApiCover(t, language).toOption)
+      new ThemeResult(covers.length, covers)
     }
 
   }

--- a/src/main/scala/no/ndla/listingapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/ReadService.scala
@@ -3,7 +3,7 @@ package no.ndla.listingapi.service
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.listingapi.caching.MemoizeAutoRenew
 import no.ndla.listingapi.model.api
-import no.ndla.listingapi.model.domain.{Lang, UniqeLabels}
+import no.ndla.listingapi.model.domain.{Lang, ThemeName, UniqeLabels}
 import no.ndla.listingapi.repository.ListingRepository
 
 trait ReadService {
@@ -11,6 +11,10 @@ trait ReadService {
   val readService: ReadService
 
   class ReadService extends LazyLogging {
+    val getAllLabelsMap = MemoizeAutoRenew(() => {
+      listingRepository.allLabelsMap()
+    })
+
     def coverWithId(id: Long, language: String): Option[api.Cover] = {
       listingRepository.getCover(id).flatMap(c => converterService.toApiCover(c, language).toOption)
     }
@@ -19,9 +23,10 @@ trait ReadService {
       getAllLabelsMap()
     }
 
-    val getAllLabelsMap = MemoizeAutoRenew(() => {
-      listingRepository.allLabelsMap()
-    })
+    def getTheme(theme: ThemeName, language: String): Seq[api.Cover] = {
+      listingRepository.getTheme(theme).flatMap(t => converterService.toApiCover(t, language).toOption)
+    }
 
   }
+
 }

--- a/src/main/scala/no/ndla/listingapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/WriteService.scala
@@ -56,7 +56,8 @@ trait WriteService {
         description = mergeLanguageField[String, Description](existing.description, domain.Description(toMerge.description, Option(toMerge.language))),
         labels = mergeLanguageField[Seq[Label], LanguageLabels](existing.labels, domain.LanguageLabels(toMerge.labels.map(converterService.toDomainLabel), Option(toMerge.language))),
         updatedBy = id,
-        updated = now
+        updated = now,
+        theme = toMerge.theme
       )
     }
 

--- a/src/main/scala/no/ndla/listingapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/search/IndexService.scala
@@ -104,7 +104,8 @@ trait IndexService {
           intField("revision") index "not_analyzed",
           textField("supportedLanguages") index "not_analyzed",
           textField("updatedBy") index "not_analyzed",
-          dateField("update") index "not_analyzed"
+          dateField("update") index "not_analyzed",
+          textField("theme") index "not_analyzed"
         ),
         ListingApiProperties.SearchDocument).string()
     }

--- a/src/main/scala/no/ndla/listingapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/search/SearchConverterService.scala
@@ -32,7 +32,8 @@ trait SearchConverterService {
             SearchableLanguageList(card.labels.map(label => LanguageValue(label.language, label.labels))),
             supportedLanguages,
             card.updatedBy,
-            card.updated
+            card.updated,
+            card.theme
           )
       }
     }

--- a/src/main/scala/no/ndla/listingapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/search/SearchService.scala
@@ -19,6 +19,7 @@ import no.ndla.listingapi.model.api
 import no.ndla.listingapi.model.api.NdlaSearchException
 import no.ndla.listingapi.model.domain._
 import no.ndla.listingapi.model.domain.search.Sort
+import no.ndla.listingapi.model.meta.Theme
 import no.ndla.listingapi.service.Clock
 import org.apache.lucene.search.join.ScoreMode
 import org.elasticsearch.ElasticsearchException
@@ -74,7 +75,8 @@ trait SearchService {
             labels.map(x => api.Label(Option(x.get("type")).map(_.getAsString), x.get("labels").getAsJsonArray.asScala.toSeq.map(_.getAsString))).toSeq,
             hit.get("supportedLanguages").getAsJsonArray.asScala.toSeq.map(_.getAsString),
             hit.get("updatedBy").getAsString,
-            clock.toDate(hit.get("update").getAsString)
+            clock.toDate(hit.get("update").getAsString),
+            hit.get("theme").getAsString
           )
       })
     }

--- a/src/test/scala/no/ndla/listingapi/TestData.scala
+++ b/src/test/scala/no/ndla/listingapi/TestData.scala
@@ -1,7 +1,6 @@
 package no.ndla.listingapi
 
 import no.ndla.listingapi.model.domain.{Label, LanguageLabels}
-import no.ndla.listingapi.model.meta.Theme
 import no.ndla.listingapi.model.{api, domain}
 import org.joda.time.{DateTime, DateTimeZone}
 

--- a/src/test/scala/no/ndla/listingapi/TestData.scala
+++ b/src/test/scala/no/ndla/listingapi/TestData.scala
@@ -1,6 +1,7 @@
 package no.ndla.listingapi
 
 import no.ndla.listingapi.model.domain.{Label, LanguageLabels}
+import no.ndla.listingapi.model.meta.Theme
 import no.ndla.listingapi.model.{api, domain}
 import org.joda.time.{DateTime, DateTimeZone}
 
@@ -16,7 +17,8 @@ object TestData {
     Seq(LanguageLabels(Seq(Label(Some("kategori"), Seq("personlig verktøy", "bygg verktøy")), Label(None, Seq("bygg"))), Some("nb"))),
     1122,
     "NDLA import script",
-    updated
+    updated,
+    "verktoy"
   )
 
   val sampleCover2 = domain.Cover(
@@ -39,7 +41,8 @@ object TestData {
     ),
     1122,
     "NDLA import script",
-    updated
+    updated,
+    "verktoy"
   )
 
 
@@ -53,7 +56,8 @@ object TestData {
     Seq(api.Label(Some("kategori"), Seq("personlig verktøy")), api.Label(None, Seq("bygg"))),
     Seq("nb"),
     "NDLA import script",
-    updated
+    updated,
+    "verktoy"
   )
 
   val sampleApiNewCover = api.NewCover(
@@ -63,7 +67,8 @@ object TestData {
     "En hammer er et nyttig verktøy",
     1122,
     None,
-    Seq(api.Label(Some("kategori"), Seq("personlig verktøy")), api.Label(None, Seq("bygg")))
+    Seq(api.Label(Some("kategori"), Seq("personlig verktøy")), api.Label(None, Seq("bygg"))),
+    "verktoy"
   )
 
   val sampleApiUpdateCover = api.UpdateCover(
@@ -73,7 +78,8 @@ object TestData {
     None,
     "hammer",
     "En hammer er et nyttig verktøy",
-    Seq(api.Label(Some("kategori"), Seq("personlig verktøy")), api.Label(None, Seq("bygg")))
+    Seq(api.Label(Some("kategori"), Seq("personlig verktøy")), api.Label(None, Seq("bygg"))),
+    "verktoy"
   )
 
   def updated() = (new DateTime(2017, 4, 1, 12, 15, 32, DateTimeZone.UTC)).toDate

--- a/src/test/scala/no/ndla/listingapi/controller/ListingControllerTest.scala
+++ b/src/test/scala/no/ndla/listingapi/controller/ListingControllerTest.scala
@@ -156,4 +156,17 @@ class ListingControllerTest extends UnitSuite with TestEnvironment with Scalatra
     }
   }
 
+
+  test("That GET /theme/:theme returns 200 and sequence of covers of that theme"){
+    get("/test/theme/verktoy") {
+      status should equal (200)
+    }
+  }
+
+  test("That GET /theme/:theme returns 400 on non valid theme"){
+    get("/test/theme/notValid") {
+      status should equal (404)
+    }
+  }
+
 }

--- a/src/test/scala/no/ndla/listingapi/controller/ListingControllerTest.scala
+++ b/src/test/scala/no/ndla/listingapi/controller/ListingControllerTest.scala
@@ -42,7 +42,8 @@ class ListingControllerTest extends UnitSuite with TestEnvironment with Scalatra
                |    ],
                |    "articleApiId": 1234,
                |    "description": "dogs and cats",
-               |    "coverPhotoUrl": "https://image.imgs/catdog.jpg"
+               |    "coverPhotoUrl": "https://image.imgs/catdog.jpg",
+               |    "theme": "verktoy"
                |}
              """.stripMargin
 

--- a/src/test/scala/no/ndla/listingapi/controller/ListingControllerTest.scala
+++ b/src/test/scala/no/ndla/listingapi/controller/ListingControllerTest.scala
@@ -165,7 +165,7 @@ class ListingControllerTest extends UnitSuite with TestEnvironment with Scalatra
 
   test("That GET /theme/:theme returns 400 on non valid theme"){
     get("/test/theme/notValid") {
-      status should equal (404)
+      status should equal (400)
     }
   }
 

--- a/src/test/scala/no/ndla/listingapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/listingapi/service/ConverterServiceTest.scala
@@ -31,7 +31,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
         api.Label(None, Seq("bygg"))),
       Seq("nb"),
       "NDLA import script",
-      sampleCover.updated
+      sampleCover.updated,
+      sampleCover.theme
     )
     service.toApiCover(sampleCover, "nb") should equal (Success(expected))
   }

--- a/src/test/scala/no/ndla/listingapi/service/CoverValidatorTest.scala
+++ b/src/test/scala/no/ndla/listingapi/service/CoverValidatorTest.scala
@@ -41,6 +41,10 @@ class CoverValidatorTest extends UnitSuite with TestEnvironment {
     service.validate(sampleCover.copy(articleApiId = -1)).isFailure should be(true)
   }
 
+  test("validate returns a failure if theme is not one of the allowed themes"){
+    service.validate(sampleCover.copy(theme = "not")).isFailure should be(true)
+  }
+
   test("validate returns success if cover is valid") {
     service.validate(sampleCover).isSuccess should be (true)
   }

--- a/src/test/scala/no/ndla/listingapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/listingapi/service/WriteServiceTest.scala
@@ -134,7 +134,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       sampleCover.labels ++ Seq(LanguageLabels(Seq(domainLabel), Some(toUpdate.language))),
       sampleCover.articleApiId,
       sampleCover.updatedBy,
-      sampleCover.updated
+      sampleCover.updated,
+      sampleCover.theme
     )
 
     when(converterService.toDomainLabel(any[Label])).thenReturn(domainLabel)
@@ -161,7 +162,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       Seq(LanguageLabels(Seq(domainLabel), Some(toUpdate.language))),
       sampleCover.articleApiId,
       sampleCover.updatedBy,
-      sampleCover.updated
+      sampleCover.updated,
+      sampleCover.theme
     )
 
     when(converterService.toDomainLabel(any[Label])).thenReturn(domainLabel)
@@ -188,7 +190,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       Seq(LanguageLabels(Seq(domainLabel), Some(toUpdate.language))),
       toUpdate.articleApiId.get,
       "NDLA import script",
-      sampleCover.updated
+      sampleCover.updated,
+      sampleCover.theme
     )
 
     when(converterService.toDomainLabel(any[Label])).thenReturn(domainLabel)
@@ -216,7 +219,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       Seq(LanguageLabels(Seq(domainLabel), Some(toUpdate.language))),
       toUpdate.articleApiId.get,
       "NDLA import script",
-      sampleCover.updated
+      sampleCover.updated,
+      sampleCover.theme
     )
 
     when(converterService.toDomainLabel(any[Label])).thenReturn(domainLabel)

--- a/src/test/scala/no/ndla/listingapi/service/search/SearchConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/listingapi/service/search/SearchConverterServiceTest.scala
@@ -36,7 +36,8 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       SearchableLanguageList(Seq(LanguageValue(Some("nb"), sampleCover.labels.head.labels))),
       Seq("nb"),
       sampleCover.updatedBy,
-      TestData.updated()
+      TestData.updated(),
+      sampleCover.theme
     )
 
     searchConverterService.asSearchableCover(sampleCover) should equal (expected)


### PR DESCRIPTION
Innført noe jeg har valgte å kalle theme, av mangel nå et ord som ikke allerede har blitt kuppet av NDLA domenet, for å kunne separere listing grupperinger som bruker ikke skal forholde seg til. P.t. verktoy og naturfag. 
listing-frontend skal ta ibruk det nye endepunktet for sin egen forskjellsbehandling av "themes" i visning av listings.