### PR TITLE
Ndlano/issues#580 pagination over 10000 results

### DIFF
--- a/src/main/scala/no/ndla/listingapi/ListingApiProperties.scala
+++ b/src/main/scala/no/ndla/listingapi/ListingApiProperties.scala
@@ -50,6 +50,7 @@ object ListingApiProperties extends LazyLogging {
   val CorrelationIdHeader = "X-Correlation-ID"
 
   val ApiClientsCacheAgeInMs: Long = 1000 * 60 * 60 // 1 hour caching
+  val ElasticSearchIndexMaxResultWindow = 10000
 
   lazy val secrets = readSecrets(SecretsFile) match {
      case Success(values) => values

--- a/src/main/scala/no/ndla/listingapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/listingapi/controller/NdlaController.scala
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest
 import com.amazonaws.services.kms.model.AlreadyExistsException
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.listingapi.ListingApiProperties.{CorrelationIdHeader, CorrelationIdKey}
-import no.ndla.listingapi.model.api.{AccessDeniedException, CoverAlreadyExistsException, Error, NotFoundException, OptimisticLockException, ValidationError, ValidationException, ValidationMessage}
+import no.ndla.listingapi.model.api.{AccessDeniedException, CoverAlreadyExistsException, Error, NotFoundException, OptimisticLockException, ResultWindowTooLargeException, ValidationError, ValidationException, ValidationMessage}
 import no.ndla.network.{ApplicationUrl, AuthUser, CorrelationID}
 import org.apache.logging.log4j.ThreadContext
 import org.elasticsearch.index.IndexNotFoundException
@@ -51,6 +51,7 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
     case e: IndexNotFoundException => InternalServerError(body=Error.IndexMissingError)
     case o: OptimisticLockException => Conflict(body=Error(Error.RESOURCE_OUTDATED, o.getMessage))
     case e: CoverAlreadyExistsException => Conflict(body=Error(Error.ALREADY_EXISTS, e.getMessage, Some(e.id)))
+    case rw: ResultWindowTooLargeException => UnprocessableEntity(body = Error(Error.WINDOW_TOO_LARGE, rw.getMessage))
     case t: Throwable => {
       logger.error(Error.GenericError.toString, t)
       InternalServerError(body=Error.GenericError)

--- a/src/main/scala/no/ndla/listingapi/model/api/Error.scala
+++ b/src/main/scala/no/ndla/listingapi/model/api/Error.scala
@@ -42,9 +42,11 @@ object Error {
   val VALIDATION_DESCRIPTION = "Validation Error"
   val INDEX_MISSING_DESCRIPTION = s"Ooops. Our search index is not available at the moment, but we are trying to recreate it. Please try again in a few minutes. Feel free to contact ${ListingApiProperties.ContactEmail} if the error persists."
   val RESOURCE_OUTDATED_DESCRIPTION = "The resource is outdated. Please try fetching before submitting again."
+  val WINDOW_TOO_LARGE = "RESULT WINDOW TOO LARGE"
 
   val GenericError = Error(GENERIC, GENERIC_DESCRIPTION)
   val IndexMissingError = Error(INDEX_MISSING, INDEX_MISSING_DESCRIPTION)
+  val WindowTooLargeError = Error(WINDOW_TOO_LARGE, s"The result window is too large. Fetching pages above ${ListingApiProperties.ElasticSearchIndexMaxResultWindow} results are unsupported.")
 }
 
 class NotFoundException(message: String = "The cover was not found") extends RuntimeException(message)
@@ -55,3 +57,4 @@ class OptimisticLockException(message: String = Error.RESOURCE_OUTDATED_DESCRIPT
 class NdlaSearchException(jestResponse: JestResult) extends RuntimeException(jestResponse.getErrorMessage) {
   def getResponse: JestResult = jestResponse
 }
+class ResultWindowTooLargeException(message: String = Error.WindowTooLargeError.description) extends RuntimeException(message)

--- a/src/main/scala/no/ndla/listingapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/listingapi/service/search/IndexService.scala
@@ -81,6 +81,7 @@ trait IndexService {
           .put(s"analysis.analyzer.${labelAnalyzer.name}.type", "custom")
           .put(s"analysis.analyzer.${labelAnalyzer.name}.tokenizer", "keyword")
           .put(s"analysis.analyzer.${labelAnalyzer.name}.filter", "lowercase")
+          .put(s"index.max_result_window", ListingApiProperties.ElasticSearchIndexMaxResultWindow)
           .build().getAsMap
 
         val createIndexResponse = jestClient.execute(new CreateIndex.Builder(indexName).settings(analyserSettings).build())


### PR DESCRIPTION
- Setter `index.max_result_window` verdien i elasticsearch når index'er lages
- Error handling når det requestes pages etter `index.max_result_window` results